### PR TITLE
MSVC compatibility

### DIFF
--- a/src/include/parsco/combinator.hpp
+++ b/src/include/parsco/combinator.hpp
@@ -28,6 +28,7 @@
 #pragma once
 
 // parsco
+#include "parsco/unreachable.hpp"
 #include "parsco/ext.hpp"
 #include "parsco/parser.hpp"
 #include "parsco/promise.hpp"
@@ -404,7 +405,7 @@ struct OnError {
     auto res = co_await try_{ std::move( p ) };
     if( res.has_value() ) co_return *res;
     co_await fail( msg );
-    __builtin_unreachable();
+    parsco::unreachable();
   }
 };
 
@@ -440,7 +441,7 @@ struct Diagnose {
     co_await fail(
         "parsing partially succeeded but was not able to "
         "consume all input." );
-    __builtin_unreachable();
+    parsco::unreachable();
   }
 };
 

--- a/src/include/parsco/unreachable.hpp
+++ b/src/include/parsco/unreachable.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace parsco {
+
+#ifdef _MSC_VER
+[[noreturn]] inline void unreachable() { __assume( 0 ); }
+#elif defined( __clang__ ) or defined( __GNUC__ ) or \
+    defined( __INTEL_COMPILER )
+[[noreturn]] inline void unreachable() {
+  __builtin_unreachable();
+}
+#else
+inline void unreachable() {}
+#endif
+
+} // namespace parsco

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -85,7 +85,7 @@ optional<BuiltinParseResult> builtin_single_quoted::try_parse(
     if( in[pos++] == '\'' ) break;
   }
   assert( pos >= 2 );
-  string_view res( in.begin() + 1, pos - 2 );
+  string_view res( in.data() + 1, pos - 2 );
   return BuiltinParseResult{ .sv = res, .consumed = pos };
 };
 
@@ -99,7 +99,7 @@ optional<BuiltinParseResult> builtin_double_quoted::try_parse(
     if( in[pos++] == '"' ) break;
   }
   assert( pos >= 2 );
-  string_view res( in.begin() + 1, pos - 2 );
+  string_view res( in.data() + 1, pos - 2 );
   return BuiltinParseResult{ .sv = res, .consumed = pos };
 };
 


### PR DESCRIPTION
Nice library!
Currently there just seem to be two little problems preventing this from working on MSVC:
* using __builtin_unreachable
* debug iterators foul up the use of the string_view(pointer, size) constructor with string_view::begin()

So here's a PR where I tried to fix those :)
